### PR TITLE
Add: Display "ReadOnly" status in status bar when loading read-only d…

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,4 +1,5 @@
 [
+  { "caption": "-", "id": "file" },  
   {
     "caption": "Read-Only Locked",
     "command": "toggle_readonly_mode",

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,6 +1,6 @@
 [
   {
-    "caption": "Toggle Readonly mode",
+    "caption": "Read-Only Locked",
     "command": "toggle_readonly_mode",
     "id": "readonly"
   }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # sublime-readonly
-Set default readonly mode by `"read_only_mode" = true` in your setting. Toggle a view's readonly mode in context menu or via command.
+- Set default readonly mode by `"read_only_mode" = true` in your setting. 
+- Toggle a view's readonly mode in context menu or via command.
+- Display "ReadOnly" status in status bar When loading a read-only file or setting a read-only mode.

--- a/readonly.py
+++ b/readonly.py
@@ -11,6 +11,9 @@ class ToggleReadonlyModeCommand(sublime_plugin.TextCommand):
       self.view.set_read_only(True)
       self.view.set_status('read_only_mode', 'ReadOnly')
 
+  def is_checked(self):
+    return self.view.is_read_only()
+
 class ToggleReadonlyListener(sublime_plugin.EventListener):
   def on_load_async(self, view):
     if view.is_read_only():

--- a/readonly.py
+++ b/readonly.py
@@ -4,19 +4,17 @@ import sublime_plugin
 
 class ToggleReadonlyModeCommand(sublime_plugin.TextCommand):
   def run(self, edit):
-    if (self.view.is_read_only()):
+    if self.view.is_read_only():
       self.view.set_read_only(False)
-      self.view.set_status('read_only_mode', 'writeable')
-      self.view.window().status_message("View " + str(self.view.file_name()) + " is writeable.")
+      self.view.erase_status('read_only_mode')
     else:
       self.view.set_read_only(True)
-      self.view.set_status('read_only_mode', 'readonly')
-      self.view.window().status_message("View " + str(self.view.file_name()) + " is readonly.")
-
+      self.view.set_status('read_only_mode', 'ReadOnly')
 
 class ToggleReadonlyListener(sublime_plugin.EventListener):
-   def on_load(self, view):
-      if view.settings().get('read_only_mode'):
-        view.set_read_only(True)
-        view.set_status('read_only_mode', 'readonly')
-        view.window().status_message("View " + str(view.file_name()) + " is readonly.")
+  def on_load_async(self, view):
+    if view.is_read_only():
+      view.set_status('read_only_mode', 'ReadOnly')
+    elif view.settings().get('read_only_mode'):
+       view.set_read_only(True)
+       view.set_status('read_only_mode', 'ReadOnly')


### PR DESCRIPTION
…ocuments, etc.

1. To cancel the status bar message when the document is read-only or no, using only the status bar "ReadOnly" status. The Status bar message may be a bit redundant.
2. Use of on_load_async() instead of on_load()
3. add: display "ReadOnly" status in status bar when loading read-only documents (e.g. loading system setting files)